### PR TITLE
fix issure #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.o
-cryptofuzz
+/cryptofuzz
 generate_corpus
 generate_dict
 modules/*/*.a

--- a/include/cryptofuzz/operations.h
+++ b/include/cryptofuzz/operations.h
@@ -875,6 +875,7 @@ class KDF_SRTP : public Operation {
             key.Serialize(ds);
             salt.Serialize(ds);
             ds.Put<>(kdr);
+            ds.Put<>(index);
             ds.Put<>(key1Size);
             ds.Put<>(key2Size);
             ds.Put<>(key3Size);
@@ -931,6 +932,7 @@ class KDF_SRTCP : public Operation {
             key.Serialize(ds);
             salt.Serialize(ds);
             ds.Put<>(kdr);
+            ds.Put<>(index);
             ds.Put<>(key1Size);
             ds.Put<>(key2Size);
             ds.Put<>(key3Size);
@@ -1644,6 +1646,8 @@ class DSA_PrivateToPublic : public Operation {
                 (modifier == rhs.modifier);
         }
         void Serialize(Datasource& ds) const {
+            g.Serialize(ds);
+            p.Serialize(ds);
             priv.Serialize(ds);
         }
 };


### PR DESCRIPTION
DSA_PrivateToPublic: The serializer only wrote priv, but the generator/modules expect p, g, and priv. The OpenSSL backend also only set priv and never set p/g, so key generation effectively fails. Fix: in DSA_PrivateToPublic::Serialize, emit g, p, and priv in that order. In modules/openssl/module.cpp, parse op.p/op.g/op.priv into BIGNUMs and compute pub = g^priv mod p (e.g., via BN_mod_exp), returning the decimal string so the OpenSSL backend can produce a public key.

KDF_SRTP / KDF_SRTCP: The serializers omitted index, but the generator fills it and the wolfCrypt implementations consume it. Fix: in the corresponding Serialize methods, write out index along with key/salt/kdr/key1-3Size.