### PR TITLE
NSS: Fix build

### DIFF
--- a/modules/nss/Makefile
+++ b/modules/nss/Makefile
@@ -27,8 +27,10 @@ module.a: module.o bn_ops.o
 	ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libhw-acc-crypto-avx.a && \
 	ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libhw-acc-crypto-avx2.a && \
 	ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libgcm-aes-x86_c_lib.a && \
-	ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-s_lib.a && \
-	ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-wrap_c_lib.a
+	ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-wrap_c_lib.a && \
+	if [ -f "$(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-s_lib.a" ]; then \
+		ar x $(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-s_lib.a; \
+	fi
 
 	ar rcs module.a module.o bn_ops.o tmp/*.o
 	rm -rf tmp/
@@ -61,7 +63,7 @@ poc : poc.cpp
 		$(NSS_NSPR_PATH)/dist/Debug/lib/libhw-acc-crypto-avx.a \
 		$(NSS_NSPR_PATH)/dist/Debug/lib/libhw-acc-crypto-avx2.a \
 		$(NSS_NSPR_PATH)/dist/Debug/lib/libgcm-aes-x86_c_lib.a \
-		$(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-s_lib.a \
+		$(shell [ -f $(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-s_lib.a ] && echo $(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-s_lib.a) \
 		$(NSS_NSPR_PATH)/dist/Debug/lib/libintel-gcm-wrap_c_lib.a \
 		-lsqlite3 \
 		-o poc


### PR DESCRIPTION
In #10, we fixed the build by including a new library in the bundle. The library however only exists in 64-bit builds.