### PR TITLE
with wolfSSL compat layer match OpenSSL try decrypt cases

### DIFF
--- a/executor.cpp
+++ b/executor.cpp
@@ -127,7 +127,8 @@ template<> void ExecutorBase<component::Ciphertext, operation::SymmetricEncrypt>
 
         bool tryDecrypt = true;
 
-        if ( module->ID == CF_MODULE("OpenSSL") ) {
+        if ( module->ID == CF_MODULE("OpenSSL") ||
+             module->ID == CF_MODULE("wolfCrypt-OpenSSL") ) {
             switch ( op.cipher.cipherType.Get() ) {
                 case    ID("Cryptofuzz/Cipher/AES_128_OCB"):
                 case    ID("Cryptofuzz/Cipher/AES_256_OCB"):


### PR DESCRIPTION
Change made to try to resolve this oss-fuzz issue https://issues.oss-fuzz.com/issues/474389120 where the crypto fuzz harness would continue on to try a decryption with wolfSSL and fail and compare that result with OpenSSL where it did not continue on to try a decryption.